### PR TITLE
Improve reconnection messages and reduce spam

### DIFF
--- a/src/main/java/com/globalchat/GlobalChatPlugin.java
+++ b/src/main/java/com/globalchat/GlobalChatPlugin.java
@@ -232,21 +232,27 @@ public class GlobalChatPlugin extends Plugin {
 									// Check connection after a delay and notify user if failed
 									scheduler.schedule(() -> {
 										if (!ablyManager.isConnected()) {
-											clientThread.invokeLater(() -> {
-												client.addChatMessage(ChatMessageType.GAMEMESSAGE, "",
-													"<col=ff9040>Global Chat connection issue - retrying...</col>", null);
-												return true;
-											});
+											// Only show message every 5 attempts to reduce spam
+											if (reconnectAttempts % 5 == 1) {
+												clientThread.invokeLater(() -> {
+													client.addChatMessage(ChatMessageType.GAMEMESSAGE, "",
+														"<col=ff9040>Global Chat at connection limit (200 players max) - retrying... Support on Patreon to increase limits!</col>", null);
+													return true;
+												});
+											}
 										}
 									}, 2000, TimeUnit.MILLISECONDS);
 									
 								} catch (Exception e) {
 									log.debug("Error during reconnection", e);
-									clientThread.invokeLater(() -> {
-										client.addChatMessage(ChatMessageType.GAMEMESSAGE, "",
-											"<col=ff0000>Global Chat connection failed</col>", null);
-										return true;
-									});
+									// Only show error message every 5 attempts to reduce spam
+									if (reconnectAttempts % 5 == 1) {
+										clientThread.invokeLater(() -> {
+											client.addChatMessage(ChatMessageType.GAMEMESSAGE, "",
+												"<col=ff0000>Global Chat full - 200 player limit reached! Support on Patreon to increase connection limits!</col>", null);
+											return true;
+										});
+									}
 								}
 							});
 						}


### PR DESCRIPTION
## Summary
Improves the user experience when Global Chat reaches connection limits by reducing message spam and clearly explaining the issue.

## Changes
- Only show reconnection messages every 5 attempts (reduces spam from ~1 message/minute to ~1 message/5 minutes)
- Changed vague "connection issue" to explicit "Global Chat at connection limit (200 players max)"
- Changed "connection failed" to "Global Chat full - 200 player limit reached\!"
- Both messages now encourage Patreon support to help increase limits

## Why
- Users were getting spammed with reconnection messages
- Messages didn't clearly explain that the issue was capacity limits, not technical problems
- Users didn't know they could help by supporting on Patreon

## Test Plan
- [x] Verify messages only appear on attempts 1, 6, 11, 16, etc.
- [x] Confirm messages clearly state the 200 player limit
- [x] Ensure Patreon call-to-action is included

🤖 Generated with Claude Code